### PR TITLE
Add option menu for pot2

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,6 +115,36 @@ bool isBurstOn = false;  // Track if we're in a burst or pause phase
 unsigned long lastSwitchTime = 0;
 int presetIndex = 0;    // Current frequency preset
 
+enum Option {
+        OPTION_FREQ_MODE = 0,
+        OPTION_BITRATE,
+        OPTION_DUTY_CYCLE,
+        OPTION_WAVE_SHAPE,
+        NUM_OPTIONS
+};
+
+const char *OPTION_NAMES[] = {
+        "Freq",
+        "Bits",
+        "Duty",
+        "Wave"
+};
+
+enum WaveShape {
+        WAVE_SAW = 0,
+        WAVE_SIN,
+        WAVE_SQUARE,
+        WAVE_INV_SAW,
+        NUM_WAVES
+};
+
+const char *WAVE_NAMES[] = {"saw", "sin", "square", "invSaw"};
+
+int currentOption = OPTION_FREQ_MODE;
+int bitrate = 8;                // default resolution bits
+int dutyCycleSetting = 512;     // default duty cycle
+int waveShape = WAVE_SAW;
+
 int buttonRState = LOW;
 int lastButtonRState = LOW;
 int buttonLState = LOW;
@@ -136,8 +166,8 @@ int calculateSafeResolution(int pwmFreq) {
 	return resolution -3;
 }
 
-void updatePWM(int timer_num, int freq_hz) {
-	int safeResolution = calculateSafeResolution(freq_hz);
+void updatePWM(int timer_num, int freq_hz, int resolution_bits) {
+        int safeResolution = resolution_bits > 0 ? resolution_bits : calculateSafeResolution(freq_hz);
 
 	ledc_timer_config_t ledc_timer = {
 			.speed_mode = LEDC_LOW_SPEED_MODE,
@@ -210,8 +240,8 @@ void setup() {
 	// Disable touch functionality for GPIO 4 (T0)
 	touch_pad_deinit();
 
-	int initialFrequency = 1000; // or whatever your starting frequency is
-	int safeResolution = calculateSafeResolution(initialFrequency);
+        int initialFrequency = 1000; // or whatever your starting frequency is
+        int safeResolution = bitrate;
 	Serial.print("Initial Safe Resolution: ");
 	Serial.println(safeResolution);
 
@@ -260,14 +290,14 @@ void setup() {
 
 
 
-	ledc_timer_config_t ledc_timer = {
-			.speed_mode = LEDC_LOW_SPEED_MODE,
-			.duty_resolution = PWM_RESOLUTION,
-			.timer_num = LEDC_TIMER_0,
-			.freq_hz = 1000,
-			.clk_cfg = LEDC_AUTO_CLK
-	};
-	ledc_timer_config(&ledc_timer);
+        ledc_timer_config_t ledc_timer = {
+                        .speed_mode = LEDC_LOW_SPEED_MODE,
+                        .duty_resolution = (ledc_timer_bit_t)bitrate,
+                        .timer_num = LEDC_TIMER_0,
+                        .freq_hz = 1000,
+                        .clk_cfg = LEDC_AUTO_CLK
+        };
+        ledc_timer_config(&ledc_timer);
 }
 
 void loop() {
@@ -292,31 +322,22 @@ void loop() {
                 if (readingR != buttonRState) {
                         buttonRState = readingR;
 
-                        // Print button state
                         if (buttonRState == LOW) {
-                                Serial.println("Button R Pressed");
-                                if (presetIndex < NUM_PRESETS - 1) presetIndex++;
-                                Serial.print("Preset: ");
-                                Serial.println(presetIndex);
-                        } else {
-                                Serial.println("Button R Released");
+                                if (currentOption < NUM_OPTIONS - 1) currentOption++;
+                                Serial.print("Option: ");
+                                Serial.println(currentOption);
                         }
                 }
         }
 
-        // If stable for debounce delay, update state
         if ((millis() - lastDebounceTimeL) > debounceDelay) {
                 if (readingL != buttonLState) {
                         buttonLState = readingL;
 
-                        // Print button state
                         if (buttonLState == LOW) {
-                                Serial.println("Button L Pressed");
-                                if (presetIndex > 0) presetIndex--;
-                                Serial.print("Preset: ");
-                                Serial.println(presetIndex);
-                        } else {
-                                Serial.println("Button L Released");
+                                if (currentOption > 0) currentOption--;
+                                Serial.print("Option: ");
+                                Serial.println(currentOption);
                         }
                 }
         }
@@ -325,7 +346,23 @@ void loop() {
 	lastButtonLState = readingL;
         display.print("L: "); display.print(lastButtonLState ? "Off" : "On");
         display.print(" \t R: "); display.println(lastButtonRState ? "Off" : "On");
-        display.print("Preset: "); display.println(FREQUENCY_PRESETS[presetIndex].label);
+        display.print("Opt: "); display.print(OPTION_NAMES[currentOption]);
+        display.print(" ");
+        switch(currentOption) {
+                case OPTION_FREQ_MODE:
+                        display.println(FREQUENCY_PRESETS[presetIndex].label);
+                        break;
+                case OPTION_BITRATE:
+                        display.print(bitrate);
+                        display.println(" bits");
+                        break;
+                case OPTION_DUTY_CYCLE:
+                        display.println(dutyCycleSetting);
+                        break;
+                case OPTION_WAVE_SHAPE:
+                        display.println(WAVE_NAMES[waveShape]);
+                        break;
+        }
 
 	int pot1Raw = 0;
 	esp_err_t pot1Status = adc2_get_raw(POTENTIOMETER1_PIN, ADC_WIDTH_BIT_12, &pot1Raw);
@@ -352,8 +389,23 @@ void loop() {
 	pot1Value= map(pot1Value, 0, 2047, 0, 4095);
 	pot2Value= map(pot2Value, 0, 2047, 0, 4095);
 
-	display.print("1: "); display.print(pot1Value);
-	display.print(" \t 2: "); display.println(pot2Value);
+        display.print("1: "); display.print(pot1Value);
+        display.print(" \t 2: "); display.println(pot2Value);
+
+        switch(currentOption) {
+                case OPTION_FREQ_MODE:
+                        presetIndex = map(pot2Value, 0, 4095, 0, NUM_PRESETS-1);
+                        break;
+                case OPTION_BITRATE:
+                        bitrate = map(pot2Value, 0, 4095, 1, 15);
+                        break;
+                case OPTION_DUTY_CYCLE:
+                        dutyCycleSetting = map(pot2Value, 0, 4095, 0, 1023);
+                        break;
+                case OPTION_WAVE_SHAPE:
+                        waveShape = map(pot2Value, 0, 4095, 0, NUM_WAVES-1);
+                        break;
+        }
 
 	int potRxValue = main::smoothPotValue(potRxRaw, adcBuffer3, bufferSize);
 	int potRyValue = main::smoothPotValue(potRyRaw, adcBuffer4, bufferSize);
@@ -421,8 +473,7 @@ void loop() {
                                        maxFreq);
         baseFrequency = constrain(baseFrequency, minFreq, maxFreq);
 
-	int dutyCycle = map(pot2Value, 0, 2047, 0, 1023);
-	dutyCycle = constrain(dutyCycle, 0, 1023);
+        int dutyCycle = dutyCycleSetting;
 
 	// Adjust frequency and duty cycle by ±5% using RX and RY potentiometers
 	int freqAdjustment = map(rxMapped, 0, 4095, -100, 100); // Map to ±5%
@@ -432,9 +483,9 @@ void loop() {
         dutyCycle += dutyCycle * dutyAdjustment / 100;
 
         baseFrequency = constrain(baseFrequency, minFreq, maxFreq);
-	dutyCycle = constrain(dutyCycle, 0, 1023);
+        dutyCycle = constrain(dutyCycle, 0, 1023);
 
-        updatePWM(LEDC_TIMER, static_cast<int>(baseFrequency));
+        updatePWM(LEDC_TIMER, static_cast<int>(baseFrequency), bitrate);
 // Then you set duty cycles like normal
 	ledc_set_duty(LEDC_LOW_SPEED_MODE, LEDC_CHANNEL_0, dutyCycle);
 	ledc_update_duty(LEDC_LOW_SPEED_MODE, LEDC_CHANNEL_0);


### PR DESCRIPTION
## Summary
- add option selection menu controlled by the buttons
- use POTENTIOMETER2 to edit the current option
- allow bitrate, duty-cycle and waveform settings in addition to frequency preset

## Testing
- `g++ -std=c++17 -c src/main.cpp -I.` *(fails: Arduino headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859767377ac832fbbd4ecd5bf2f8168